### PR TITLE
Update TabPreviewEnhanced.css: update panel border radius variable

### DIFF
--- a/TabPreviewEnhanced/TabPreviewEnhanced.css
+++ b/TabPreviewEnhanced/TabPreviewEnhanced.css
@@ -12,7 +12,7 @@
 	background: var(--zen-main-browser-background) !important;
 
 	/* Matches Zen panel radius */
-	border-radius: var(--zen-panel-radius);
+	border-radius: var(--panel-border-radius);
 
 	/* Shifts panel to the slightly right */
 	/* TODO: Make customizable */
@@ -39,6 +39,6 @@
 
 	canvas {
 		/* Makes tab preview image rounded */
-		border-radius: var(--zen-panel-radius) !important;
+		border-radius: var(--panel-border-radius) !important;
 	}
 }


### PR DESCRIPTION
Seems that after Zen 1.7.1b or 1.7.2b, the variable name `--zen-panel-radius` may have be changed or dismissed, so it is not set now, making the thumbnail panel and image both square.

I have tested that `--panel-border-radius` works for now.