### PR TITLE
Added new settings to preferences.json and chrome.css (Enhanced Tab Previews)

### DIFF
--- a/TabPreviewEnhanced/TabPreviewEnhanced.css
+++ b/TabPreviewEnhanced/TabPreviewEnhanced.css
@@ -1,63 +1,73 @@
-#tab-preview-panel {
-	/* Matches Zen main background color, also supports gradients */
-	@media (-moz-bool-pref: 'zen.mods.TabPreviewEnhanced.enabledBackgroundNative') {
-		--panel-background: var(--zen-main-browser-background-toolbar) !important;
+@-moz-document url-prefix("chrome:") {
+  #tab-preview-panel {
+  	/* Matches Zen main background color, also supports gradients */
+  	@media (-moz-bool-pref: 'zen.mods.TabPreviewEnhanced.enabledBackgroundNative') {
+  		--panel-background: var(--zen-main-browser-background-toolbar) !important;
+  	}
+  
+  	/* Matches Zen panel radius */
+  	@media not (-moz-bool-pref: 'zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius') {
+  		border-radius: var(--panel-border-radius) !important;
+  	}
+  
+  	/* Custom border radius for tab preview*/
+  	@media (-moz-bool-pref: 'zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius') {
+  		--panel-border-radius: var(
+  			--zen-mods-TabPreviewEnhanced-borderRadiusAmount
+  		) !important;
+  	}
+  
+  	/* Removes border around tab preview */
+  	--zen-appcontent-border: transparent !important;
+  
+  	/* Shifts panel to the slightly right */
+  	/* TODO: Make customizable */
+	@media not (-moz-bool-pref: 'zen.mods.TabPreviewEnhanced.enabledCustomMargins') {
+		margin-left: 0.5em !important;
 	}
 
-	/* Matches Zen panel radius */
-	@media not (-moz-bool-pref: 'zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius') {
-		border-radius: var(--panel-border-radius) !important;
+	@media (-moz-bool-pref: 'zen.mods.TabPreviewEnhanced.enabledCustomMargins') {
+  		margin-left: var(--mod-tabpreviewenhanced-margins) !important;
 	}
-
-	/* Custom border radius for tab preview*/
-	@media (-moz-bool-pref: 'zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius') {
-		--panel-border-radius: var(
-			--zen-mods-TabPreviewEnhanced-borderRadiusAmount
-		) !important;
-	}
-
-	/* Removes border around tab preview */
-	--zen-appcontent-border: transparent !important;
-
-	/* Shifts panel to the slightly right */
-	/* TODO: Make customizable */
-	margin-left: 0.5em !important;
-}
-
-.tab-preview-thumbnail-container {
-	/* Fixes proper tab preview image sizing */
-	&:has(canvas) {
-		@media (-moz-bool-pref: 'zen.mods.TabPreviewEnhanced.enabledMargins') {
-			/* Add padding around tab preview image */
-			padding: var(--zen-element-separation);
+  }
+  
+  .tab-preview-thumbnail-container {
+  	/* Fixes proper tab preview image sizing */
+  	&:has(canvas) {
+  		@media (-moz-bool-pref: 'zen.mods.TabPreviewEnhanced.enabledMargins') {
+  			/* Add padding around tab preview image */
+  			padding: var(--zen-element-separation);
+  		}
+  
+  		/* Hide border above preview */
+  		border-top: none !important;
+  
+  		/* Hides padding between tab preview image and tab preview title */
+  		padding-top: 0 !important;
+  
+  		/* Shrink preview to match added padding */
+		@media (-moz-bool-pref: 'zen.mods.TabPreviewEnhanced.shrinkPreview') {
+  			width: calc(var(--panel-width) - (var(--zen-element-separation) * 2)) !important;
+  			height: unset !important;
 		}
-
-		/* Hide border above preview */
-		border-top: none !important;
-
-		/* Hides padding between tab preview image and tab preview title */
-		padding-top: 0 !important;
-
-		/* Shrink preview to match added padding */
-		/* TODO: Make optional */
-		width: calc(var(--panel-width) - (var(--zen-element-separation) * 2)) px !important;
-		height: unset !important;
-
-		/* Some safety code to maintain aspect ratio */
-		aspect-ratio: 2 / 1 !important;
-	}
-
-	canvas {
-		/* Matches Zen panel radius */
-		@media not (-moz-bool-pref: 'zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius') {
-			border-radius: calc(var(--panel-border-radius) / 1.3) !important;
-		}
-
-		/* Custom border radius for tab preview image */
-		@media (-moz-bool-pref: 'zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius') {
-			border-radius: calc(
-				var(--zen-mods-TabPreviewEnhanced-borderRadiusAmount) / 1.3
-			) !important;
-		}
-	}
+  
+  		/* Some safety code to maintain aspect ratio */
+  		aspect-ratio: 2 / 1 !important;
+  	}
+  
+  	canvas {
+  		/* Matches Zen panel radius */
+  		@media not (-moz-bool-pref: 'zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius') {
+  			border-radius: calc(var(--panel-border-radius) / 1.3) !important;
+  		}
+  
+  		/* Custom border radius for tab preview image */
+  		@media (-moz-bool-pref: 'zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius') {
+  			border-radius: calc(
+  				var(--mod-tabpreviewenhanced-borderradius) / 1.3
+  			) !important;
+  		}
+  	}
+  }
+  
 }

--- a/TabPreviewEnhanced/preferences.json
+++ b/TabPreviewEnhanced/preferences.json
@@ -1,26 +1,44 @@
 [
     {
-        "property": "zen.mods.TabPreviewEnhanced.enabledMargins",
-        "label": "Put margins around tab preview image",
+        "property": "zen.mods.TabPreviewEnhanced.enabledBackgroundNative",
+        "label": "Enable native background on tab previews.",
         "type": "checkbox",
         "defaultValue": true
     },
     {
-        "property": "zen.mods.TabPreviewEnhanced.enabledBackgroundNative",
-        "label": "Follows background color of Zen main browser (Workspaces included)",
+        "property": "zen.mods.TabPreviewEnhanced.enabledMargins",
+        "label": "Enable margins on tab previews.",
         "type": "checkbox",
         "defaultValue": true
     },
     {
         "property": "zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius",
-        "label": "Enables custom border radius for tab preview",
+        "label": "Enable custom border radius on tab preview images.",
+        "type": "checkbox",
+        "defaultValue": false
+    },
+    {
+        "property": "mod.tabpreviewenhanced.borderradius",
+        "label": "Custom border radius (checkbox above must be enabled):",
+        "type": "string",
+        "defaultValue": "4px"
+    },
+    {
+        "property": "zen.mods.TabPreviewEnhanced.shrinkPreview",
+        "label": "Shrink tab preview images to match added padding.",
         "type": "checkbox",
         "defaultValue": true
     },
     {
-        "property": "zen.mods.TabPreviewEnhanced.borderRadiusAmount",
-        "label": "Amount of custom border radius (Only active if above is enabled)",
+        "property": "zen.mods.TabPreviewEnhanced.enabledCustomMargins",
+        "label": "Enable custom left margin to tab preview containers.",
+        "type": "checkbox",
+        "defaultValue": false
+    },
+    {
+        "property": "mod.tabpreviewenhanced.margins",
+        "label": "Custom left margin (checkbox above must be enabled):",
         "type": "string",
-        "defaultValue": "10px"
+        "defaultValue": "0.5em"
     }
 ]


### PR DESCRIPTION
In this pull request, I have added a left margin setting for tab previews. I have also added a shrink image setting (which might not be necessary, I just saw it as a comment in the chrome.css file).