### PR TITLE
feat: Switch to -moz-pref.

### DIFF
--- a/AudioIndicatorEnhanced/AudioIndicatorEnhanced.css
+++ b/AudioIndicatorEnhanced/AudioIndicatorEnhanced.css
@@ -48,7 +48,7 @@
 }
 
 /** Legacy Mode - Round circle */
-@media not (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.audioWave.enabled") {
+@media not (-moz-pref("zen.mods.AudioIndicatorEnhanced.audioWave.enabled")) {
 	#tabbrowser-tabs[orient="vertical"]
 		.tabbrowser-tab:not([zen-glance-tab])
 		> .tab-stack
@@ -64,7 +64,7 @@
 			background-repeat: no-repeat !important;
 			background-position: center !important;
 
-			@media (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.hoverScaleAnimationEnabled") {
+			@media (-moz-pref("zen.mods.AudioIndicatorEnhanced.hoverScaleAnimationEnabled")) {
 				&:hover {
 					transition: transform 100ms ease-in-out,
 						background-color 100ms ease-in-out !important;
@@ -76,12 +76,12 @@
 
 		&[soundplaying] {
 			/* Revert old icon */
-			@media (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.returnOldIcons") {
-				@media not (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.reverseAudioIcons") {
+			@media (-moz-pref("zen.mods.AudioIndicatorEnhanced.returnOldIcons")) {
+				@media not (-moz-pref("zen.mods.AudioIndicatorEnhanced.reverseAudioIcons")) {
 					background-image: url("chrome://browser/skin/tabbrowser/tab-audio-playing-small.svg") !important;
 				}
 
-				@media (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.reverseAudioIcons") {
+				@media (-moz-pref("zen.mods.AudioIndicatorEnhanced.reverseAudioIcons")) {
 					background-image: url("chrome://browser/skin/tabbrowser/tab-audio-muted-small.svg") !important;
 				}
 			}
@@ -92,12 +92,12 @@
 			background-color: rgb(122, 31, 31) !important;
 
 			/* Revert old icon */
-			@media (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.returnOldIcons") {
-				@media not (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.reverseAudioIcons") {
+			@media (-moz-pref("zen.mods.AudioIndicatorEnhanced.returnOldIcons")) {
+				@media not (-moz-pref("zen.mods.AudioIndicatorEnhanced.reverseAudioIcons")) {
 					background-image: url("chrome://browser/skin/tabbrowser/tab-audio-muted-small.svg") !important;
 				}
 
-				@media (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.reverseAudioIcons") {
+				@media (-moz-pref("zen.mods.AudioIndicatorEnhanced.reverseAudioIcons")) {
 					background-image: url("chrome://browser/skin/tabbrowser/tab-audio-playing-small.svg") !important;
 				}
 			}
@@ -105,13 +105,13 @@
 
 		&[activemedia-blocked] {
 			/* Revert old icon */
-			@media (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.returnOldIcons") {
+			@media (-moz-pref("zen.mods.AudioIndicatorEnhanced.returnOldIcons")) {
 				background-image: url("chrome://browser/skin/tabbrowser/tab-audio-blocked-small.svg") !important;
 			}
 		}
 
 		/* Revert new, zen's audio indicator */
-		@media (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.returnOldIcons") {
+		@media (-moz-pref("zen.mods.AudioIndicatorEnhanced.returnOldIcons")) {
 			&[muted],
 			&[soundplaying],
 			&[activemedia-blocked] {
@@ -149,7 +149,7 @@
 				background-color: hsl(0, 59%, 30%, 50%) !important;
 			}
 
-			@media (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.hoverScaleAnimationEnabled") {
+			@media (-moz-pref("zen.mods.AudioIndicatorEnhanced.hoverScaleAnimationEnabled")) {
 				&:hover {
 					transform: scale(1.2);
 				}
@@ -158,7 +158,7 @@
 	}
 
 	/* Patches for pinned tabs indicator while in SuperPins */
-	@media (-moz-bool-pref: "uc.pins.legacy-layout") {
+	@media (-moz-pref("uc.pins.legacy-layout")) {
 		#navigator-toolbox[zen-sidebar-expanded="true"]
 			#tabbrowser-tabs[orient="vertical"]
 			.tabbrowser-tab[pinned]
@@ -187,7 +187,7 @@
 					background-color: hsl(0, 59%, 30%, 50%) !important;
 				}
 
-				@media (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.hoverScaleAnimationEnabled") {
+				@media (-moz-pref("zen.mods.AudioIndicatorEnhanced.hoverScaleAnimationEnabled")) {
 					&:hover {
 						transform: scale(1.2);
 					}
@@ -227,7 +227,7 @@
 	}
 
 	/* Large Essential Icons Mode */
-	@media (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.bigEssentialIcons.enabled") {
+	@media (-moz-pref("zen.mods.AudioIndicatorEnhanced.bigEssentialIcons.enabled")) {
 		#navigator-toolbox
 			#tabbrowser-tabs[orient="vertical"]
 			.tabbrowser-tab[zen-essential="true"] {
@@ -249,7 +249,7 @@
 }
 
 /** Audio Wave version */
-@media (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.audioWave.enabled") {
+@media (-moz-pref("zen.mods.AudioIndicatorEnhanced.audioWave.enabled")) {
 	/** Variables section */
 	/* Normal tab bar */
 	#tabbrowser-tabs[orient="vertical"] {
@@ -263,7 +263,7 @@
 		}
 
 		/* Patch for SuperPins */
-		@media (-moz-bool-pref: "uc.pins.legacy-layout") {
+		@media (-moz-pref("uc.pins.legacy-layout")) {
 			/* Pinned tab */
 			& .tabbrowser-tab[pinned] {
 				--audio-button-top: -4px;
@@ -294,7 +294,7 @@
 		}
 
 		/* Patch for SuperPins */
-		@media (-moz-bool-pref: "uc.pins.legacy-layout") {
+		@media (-moz-pref("uc.pins.legacy-layout")) {
 			/* Pinned tab */
 			& .tabbrowser-tab[pinned] {
 				--audio-button-top: 0px;
@@ -323,7 +323,7 @@
 		}
 
 		/* Patch for SuperPins */
-		@media (-moz-bool-pref: "uc.pins.legacy-layout") {
+		@media (-moz-pref("uc.pins.legacy-layout")) {
 			/* Pinned tab */
 			& .tabbrowser-tab[pinned] {
 				--audio-wave-top: -2px;
@@ -343,7 +343,7 @@
 			}
 
 			/* Patch for SuperPins */
-			@media (-moz-bool-pref: "uc.pins.legacy-layout") {
+			@media (-moz-pref("uc.pins.legacy-layout")) {
 				/* Pinned tab */
 				& .tabbrowser-tab[pinned] {
 					--audio-wave-top: 1px;
@@ -387,11 +387,11 @@
 		> .tab-content
 		> .tab-icon-stack
 		> .tab-icon-overlay:not([crashed]) {
-		@media not (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.reverseAudioIcons") {
+		@media not (-moz-pref("zen.mods.AudioIndicatorEnhanced.reverseAudioIcons")) {
 			list-style-image: url("chrome://browser/skin/tabbrowser/tab-audio-playing-small.svg") !important;
 		}
 
-		@media (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.reverseAudioIcons") {
+		@media (-moz-pref("zen.mods.AudioIndicatorEnhanced.reverseAudioIcons")) {
 			list-style-image: url("chrome://browser/skin/tabbrowser/tab-audio-muted-small.svg") !important;
 		}
 	}
@@ -403,11 +403,11 @@
 		> .tab-content
 		> .tab-icon-stack
 		> .tab-icon-overlay:not([crashed]) {
-		@media not (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.reverseAudioIcons") {
+		@media not (-moz-pref("zen.mods.AudioIndicatorEnhanced.reverseAudioIcons")) {
 			list-style-image: url("chrome://browser/skin/tabbrowser/tab-audio-muted-small.svg") !important;
 		}
 
-		@media (-moz-bool-pref: "zen.mods.AudioIndicatorEnhanced.reverseAudioIcons") {
+		@media (-moz-pref("zen.mods.AudioIndicatorEnhanced.reverseAudioIcons")) {
 			list-style-image: url("chrome://browser/skin/tabbrowser/tab-audio-playing-small.svg") !important;
 		}
 	}
@@ -443,7 +443,7 @@
 	}
 
 	/* Patches for SuperPins compatibility */
-	@media (-moz-bool-pref: "uc.pins.legacy-layout") {
+	@media (-moz-pref("uc.pins.legacy-layout")) {
 		/* Patch for pinned tabs with SuperPins */
 		#tabbrowser-tabs[orient="vertical"]
 			.tabbrowser-tab[pinned]

--- a/StatusBarEnhanced/StatusBarEnhanced.css
+++ b/StatusBarEnhanced/StatusBarEnhanced.css
@@ -1,14 +1,14 @@
 #statuspanel-label {
 	border-style: solid !important;
 
-	@media (-moz-bool-pref: 'zen.mods.StatusBarEnhanced.enableMargins') {
+	@media (-moz-pref('zen.mods.StatusBarEnhanced.enableMargins')) {
 		margin: var(--zen-mods-StatusBarEnhanced-marginAmount, 3px) !important;
 
-		@media (-moz-bool-pref: 'zen.mods.StatusBarEnhanced.enableBorderRadiusNative') {
+		@media (-moz-pref('zen.mods.StatusBarEnhanced.enableBorderRadiusNative')) {
 			border-radius: var(--zen-border-radius) !important;
 		}
 
-		@media not (-moz-bool-pref: 'zen.mods.StatusBarEnhanced.enableBorderRadiusNative') {
+		@media not (-moz-pref('zen.mods.StatusBarEnhanced.enableBorderRadiusNative')) {
 			border-radius: var(
 				--zen-mods-StatusBarEnhanced-customBorderRadiusAmount,
 				8px
@@ -16,11 +16,11 @@
 		}
 	}
 
-	@media (-moz-bool-pref: 'zen.mods.StatusBarEnhanced.enableBackgroundColorNative') {
+	@media (-moz-pref('zen.mods.StatusBarEnhanced.enableBackgroundColorNative')) {
 		background: var(--zen-main-browser-background) !important;
 	}
 
-	@media not (-moz-bool-pref: 'zen.mods.StatusBarEnhanced.enableBackgroundColorNative') {
+	@media not (-moz-pref('zen.mods.StatusBarEnhanced.enableBackgroundColorNative')) {
 		background: var(--zen-mods-StatusBarEnhanced-customBackgroundColor) !important;
 	}
 

--- a/TabPreviewEnhanced/TabPreviewEnhanced.css
+++ b/TabPreviewEnhanced/TabPreviewEnhanced.css
@@ -1,19 +1,19 @@
 @-moz-document url-prefix("chrome:") {
 	#tab-preview-panel {
 		/* Matches Zen main background color, also supports gradients */
-		@media (-moz-bool-pref: "zen.mods.TabPreviewEnhanced.enabledBackgroundNative") {
+		@media (-moz-pref("zen.mods.TabPreviewEnhanced.enabledBackgroundNative")) {
 			--panel-background: var(
 				--zen-main-browser-background-toolbar
 			) !important;
 		}
 
 		/* Matches Zen panel radius */
-		@media not (-moz-bool-pref: "zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius") {
+		@media not (-moz-pref("zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius")) {
 			border-radius: var(--panel-border-radius) !important;
 		}
 
 		/* Custom border radius for tab preview*/
-		@media (-moz-bool-pref: "zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius") {
+		@media (-moz-pref("zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius")) {
 			--panel-border-radius: var(
 				--zen-mods-TabPreviewEnhanced-borderRadiusAmount
 			) !important;
@@ -23,11 +23,11 @@
 		--zen-appcontent-border: transparent !important;
 
 		/* Shifts panel slightly to the right */
-		@media not (-moz-bool-pref: "zen.mods.TabPreviewEnhanced.enabledCustomMargin") {
+		@media not (-moz-pref("zen.mods.TabPreviewEnhanced.enabledCustomMargin")) {
 			margin-left: 0.5em !important;
 		}
 
-		@media (-moz-bool-pref: "zen.mods.TabPreviewEnhanced.enabledCustomMargin") {
+		@media (-moz-pref("zen.mods.TabPreviewEnhanced.enabledCustomMargin")) {
 			margin-left: var(
 				--zen-mods-TabPreviewEnhanced-marginAmount
 			) !important;
@@ -38,7 +38,7 @@
 		/* Fixes proper tab preview image sizing */
 		&:has(canvas) {
 			/* TODO: Rename to include padding instead of margin (on some breaking version, probably v2, as will break current preferences) */
-			@media (-moz-bool-pref: "zen.mods.TabPreviewEnhanced.enabledMargins") {
+			@media (-moz-pref("zen.mods.TabPreviewEnhanced.enabledMargins")) {
 				/* Add padding around tab preview image */
 				padding: var(--zen-element-separation);
 			}
@@ -50,7 +50,7 @@
 			padding-top: 0 !important;
 
 			/* Shrink preview to match added padding */
-			@media (-moz-bool-pref: "zen.mods.TabPreviewEnhanced.shrinkPreview") {
+			@media (-moz-pref("zen.mods.TabPreviewEnhanced.shrinkPreview")) {
 				width: calc(
 					var(--panel-width) - (var(--zen-element-separation) * 2)
 				) !important;
@@ -63,14 +63,14 @@
 
 		canvas {
 			/* Matches Zen panel radius */
-			@media not (-moz-bool-pref: "zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius") {
+			@media not (-moz-pref("zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius")) {
 				border-radius: calc(
 					var(--panel-border-radius) / 1.3
 				) !important;
 			}
 
 			/* Custom border radius for tab preview image */
-			@media (-moz-bool-pref: "zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius") {
+			@media (-moz-pref("zen.mods.TabPreviewEnhanced.enabledCustomBorderRadius")) {
 				border-radius: calc(
 					var(--zen-mods-TabPreviewEnhanced-borderRadiusAmount) / 1.3
 				) !important;


### PR DESCRIPTION
The latest Zen Mods documentation for [checkbox preferences](https://docs.zen-browser.app/themes-store/themes-marketplace-preferences#checkbox-preferences) recommends using ```-moz-pref``` over ```-moz-bool-pref``` as the former is now natively implemented into Firefox and will be maintained, unlike the latter which was implemented by Zen exclusively and will not work anywhere else.

Thanks! :)